### PR TITLE
update the pom.xml files to make the build platform independent

### DIFF
--- a/labs/unicorn-location-api/UnicornLocationFunction/pom.xml
+++ b/labs/unicorn-location-api/UnicornLocationFunction/pom.xml
@@ -9,6 +9,8 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/labs/unicorn-location-api/final/unicorn-location-api-final/UnicornLocationFunction/pom.xml
+++ b/labs/unicorn-location-api/final/unicorn-location-api-final/UnicornLocationFunction/pom.xml
@@ -9,6 +9,8 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>

--- a/labs/unicorn-store/infrastructure/cdk/pom.xml
+++ b/labs/unicorn-store/infrastructure/cdk/pom.xml
@@ -9,6 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cdk.version>2.43.1</cdk.version>
         <junit.version>5.9.1</junit.version>
     </properties>

--- a/labs/unicorn-store/software/alternatives/unicorn-store-basic/pom.xml
+++ b/labs/unicorn-store/software/alternatives/unicorn-store-basic/pom.xml
@@ -9,6 +9,8 @@
 	<description>Unicorn storage service</description>
 	<properties>
 		<java.version>11</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/labs/unicorn-store/software/alternatives/unicorn-store-micronaut/pom.xml
+++ b/labs/unicorn-store/software/alternatives/unicorn-store-micronaut/pom.xml
@@ -19,6 +19,8 @@
     <release.version>11</release.version>
     <micronaut.version>3.1.1</micronaut.version>
     <micronaut.data.version>3.1.0</micronaut.data.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
   <repositories>

--- a/labs/unicorn-store/software/alternatives/unicorn-store-spring-native-graalvm/pom.xml
+++ b/labs/unicorn-store/software/alternatives/unicorn-store-spring-native-graalvm/pom.xml
@@ -16,6 +16,8 @@
 	<properties>
 		<java.version>11</java.version>
 		<spring-native.version>0.12.1</spring-native.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/labs/unicorn-store/software/unicorn-store-spring/pom.xml
+++ b/labs/unicorn-store/software/unicorn-store-spring/pom.xml
@@ -15,6 +15,8 @@
     <description>Unicorn storage service</description>
     <properties>
         <java.version>11</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
The build is failing, if the platform encoding is US-ASCII:

[WARNING] File encoding has not been set, using platform encoding US-ASCII, i.e. build is platform dependent!
[INFO] Compiling 13 source files to /Users/cmr/workspaceGithubmuellerc/aws-lambda-java-workshop/labs/unicorn-store/software/alternatives/unicorn-store-basic/target/classes
[ERROR] /Users/cmr/workspaceGithubmuellerc/aws-lambda-java-workshop/labs/unicorn-store/software/alternatives/unicorn-store-basic/src/main/java/com/unicorn/store/handler/UnicornGetRequestHandler.java:[32,24] unmappable character (0xC2) for encoding US-ASCII


*Description of changes:*
Added the below Maven properties to make the build platform independent:
<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
