### PR TITLE
avoid NAT Gateway creation to speed up deployment and save costs

### DIFF
--- a/labs/unicorn-store/infrastructure/cdk/src/main/java/com/unicorn/core/InfrastructureStack.java
+++ b/labs/unicorn-store/infrastructure/cdk/src/main/java/com/unicorn/core/InfrastructureStack.java
@@ -73,7 +73,7 @@ public class InfrastructureStack extends Stack {
                 .instanceIdentifier("UnicornInstance")
                 .instanceType(InstanceType.of(InstanceClass.BURSTABLE3, InstanceSize.MEDIUM))
                 .vpcSubnets(SubnetSelection.builder()
-                        .subnetType(SubnetType.PRIVATE_WITH_EGRESS)
+                        .subnetType(SubnetType.PRIVATE_ISOLATED)
                         .build())
                 .securityGroups(List.of(databaseSecurityGroup))
                 .credentials(Credentials.fromSecret(databaseSecret))
@@ -90,6 +90,7 @@ public class InfrastructureStack extends Stack {
     private IVpc createUnicornVpc() {
         return Vpc.Builder.create(this, "UnicornVpc")
                 .vpcName("UnicornVPC")
+                .natGateways(0)
                 .build();
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
NAT Gateways are not needed for the workshop so we should avoid the creation to save costs and speed up the deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
