### PR TITLE
Update GraalVM to 21.0.3

### DIFF
--- a/labs/unicorn-location-api/final/unicorn-location-api-final/Dockerfile
+++ b/labs/unicorn-location-api/final/unicorn-location-api-final/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_VERSION 21.0.3
 ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
 RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
 RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm

--- a/labs/unicorn-location-api/final/unicorn-location-api-final/Dockerfile
+++ b/labs/unicorn-location-api/final/unicorn-location-api-final/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-#Install depencencies
+#Install dependencies
 RUN yum -y update \
     && yum install -y unzip zip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
@@ -8,22 +8,17 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV JAVA_VERSION 17.0.9
-ENV GRAAL_FOLDERNAME graalvm-community-openjdk-${JAVA_VERSION}+9.1
-ENV GRAAL_FILENAME graalvm-community-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz
-RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_VERSION}/${GRAAL_FILENAME} | tar -xvz
-RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
+ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
+RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
+RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm
 
 # Maven
-ENV MVN_VERSION 3.9.5
+ENV MVN_VERSION 3.9.6
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz
 RUN mv $MVN_FOLDERNAME /usr/lib/maven
-
-#Native Image dependencies
-RUN /usr/lib/graalvm/bin/gu install native-image
-RUN ln -s /usr/lib/graalvm/bin/native-image /usr/bin/native-image
 RUN ln -s /usr/lib/maven/bin/mvn /usr/bin/mvn
 
 ENV JAVA_HOME /usr/lib/graalvm

--- a/labs/unicorn-location-api/graal/Dockerfile
+++ b/labs/unicorn-location-api/graal/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_VERSION 21.0.3
 ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
 RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
 RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm

--- a/labs/unicorn-location-api/graal/Dockerfile
+++ b/labs/unicorn-location-api/graal/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-#Install depencencies
+#Install dependencies
 RUN yum -y update \
     && yum install -y unzip zip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
@@ -8,22 +8,17 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV JAVA_VERSION 17.0.9
-ENV GRAAL_FOLDERNAME graalvm-community-openjdk-${JAVA_VERSION}+9.1
-ENV GRAAL_FILENAME graalvm-community-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz
-RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_VERSION}/${GRAAL_FILENAME} | tar -xvz
-RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
+ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
+RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
+RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm
 
 # Maven
-ENV MVN_VERSION 3.9.5
+ENV MVN_VERSION 3.9.6
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz
 RUN mv $MVN_FOLDERNAME /usr/lib/maven
-
-#Native Image dependencies
-RUN /usr/lib/graalvm/bin/gu install native-image
-RUN ln -s /usr/lib/graalvm/bin/native-image /usr/bin/native-image
 RUN ln -s /usr/lib/maven/bin/mvn /usr/bin/mvn
 
 ENV JAVA_HOME /usr/lib/graalvm

--- a/labs/unicorn-store/software/alternatives/unicorn-store-spring-graalvm/Dockerfile
+++ b/labs/unicorn-store/software/alternatives/unicorn-store-spring-graalvm/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_VERSION 21.0.3
 ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
 RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
 RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm

--- a/labs/unicorn-store/software/alternatives/unicorn-store-spring-graalvm/Dockerfile
+++ b/labs/unicorn-store/software/alternatives/unicorn-store-spring-graalvm/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-#Install depencencies
+#Install dependencies
 RUN yum -y update \
     && yum install -y unzip zip tar gzip bzip2-devel ed gcc gcc-c++ gcc-gfortran \
     less libcurl-devel openssl openssl-devel readline-devel xz-devel \
@@ -8,22 +8,17 @@ RUN yum -y update \
     && rm -rf /var/cache/yum
 
 # Graal VM
-ENV JAVA_VERSION 17.0.9
-ENV GRAAL_FOLDERNAME graalvm-community-openjdk-${JAVA_VERSION}+9.1
-ENV GRAAL_FILENAME graalvm-community-jdk-${JAVA_VERSION}_linux-x64_bin.tar.gz
-RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${JAVA_VERSION}/${GRAAL_FILENAME} | tar -xvz
-RUN mv $GRAAL_FOLDERNAME /usr/lib/graalvm
+ENV GRAAL_VERSION 21.0.2
+ENV GRAAL_FILENAME graalvm-community-jdk-${GRAAL_VERSION}_linux-x64_bin.tar.gz
+RUN curl -4 -L https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_VERSION}/${GRAAL_FILENAME} | tar -xvz
+RUN mv graalvm-community-openjdk-${GRAAL_VERSION}* /usr/lib/graalvm
 
 # Maven
-ENV MVN_VERSION 3.9.5
+ENV MVN_VERSION 3.9.6
 ENV MVN_FOLDERNAME apache-maven-${MVN_VERSION}
 ENV MVN_FILENAME apache-maven-${MVN_VERSION}-bin.tar.gz
 RUN curl -4 -L https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/${MVN_FILENAME} | tar -xvz
 RUN mv $MVN_FOLDERNAME /usr/lib/maven
-
-#Native Image dependencies
-RUN /usr/lib/graalvm/bin/gu install native-image
-RUN ln -s /usr/lib/graalvm/bin/native-image /usr/bin/native-image
 RUN ln -s /usr/lib/maven/bin/mvn /usr/bin/mvn
 
 ENV JAVA_HOME /usr/lib/graalvm


### PR DESCRIPTION
We may consider to move to the approach used in https://github.com/aws-samples/java-on-aws/blob/main/labs/unicorn-store/software/dockerfiles/Dockerfile_05_GraalVM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
